### PR TITLE
Bump devcontainer pin to 1.0.2

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
   //
   // Pinned to a semver tag (David's call, 2026-07 — this used to float
   // on dev:latest). Bump deliberately when a new release lands.
-  "image": "ghcr.io/ppbds/devcontainer:1.0.0",
+  "image": "ghcr.io/ppbds/devcontainer:1.0.2",
 
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Picks up [v1.0.1](https://github.com/PPBDS/devcontainers/releases/tag/v1.0.1) (primer.tutorials installs from its own repo) and [v1.0.2](https://github.com/PPBDS/devcontainers/releases/tag/v1.0.2) (easystats attach nag silenced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)