### PR TITLE
Bump devcontainer pin 1.0.2 → 1.0.4

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,7 @@
   //
   // Pinned to a semver tag (David's call, 2026-07 — this used to float
   // on dev:latest). Bump deliberately when a new release lands.
-  "image": "ghcr.io/ppbds/devcontainer:1.0.2",
+  "image": "ghcr.io/ppbds/devcontainer:1.0.4",
 
   "customizations": {
     "vscode": {


### PR DESCRIPTION
Two releases behind: picks up v1.0.3 (Suggests-as-contract installs) and v1.0.4 (baked R Tutorials extension from Open VSX).

🤖 Generated with [Claude Code](https://claude.com/claude-code)