### PR TITLE
Edit authoring.md: Exercise headers need a real question_text() chunk

### DIFF
--- a/guide/authoring.md
+++ b/guide/authoring.md
@@ -303,7 +303,9 @@ Example: if the last exercise in Wisdom polishes a scatter plot, the topic-final
 
 ### 6.5 Continue buttons without a real question
 
-When you need a pause point in the flow — to display an author-shown table, formula, or plot, then let the student read it before moving on — use a **standalone `###`** (triple hash, no heading, no question). That alone produces a Continue button that advances the student. Do **not** create a fake `### Exercise N` with a placeholder `question_text()` containing *"(No command to run — this exercise is a pause to make sure you have read the table above.)"*. Those placeholders are noise: they pretend to be exercises, they bump the exercise count, and they ask the student to type/click for no reason.
+When you need a pause point in the flow — to display an author-shown table, formula, or plot, then let the student read it before moving on — use a **standalone `###`** (triple hash, no heading, no question). That alone produces a Continue button that advances the student.
+
+**Every `### Exercise N` heading must be followed by an actual `question_text()` chunk before the next `###` or `##` heading.** Two variants of the same mistake are both forbidden: a fake `### Exercise N` with a placeholder `question_text()` containing *"(No command to run — this exercise is a pause to make sure you have read the table above.)"*, and a `### Exercise N` heading with **no** `question_text()` chunk at all — just prose, a formula, or a plot, with nothing for the student to submit. The second form is easy to write by accident (an author-shown formula naturally looks like it deserves its own numbered step) but it is exactly as wrong as the first: both pretend to be exercises, both bump the exercise count, and both ask the student to click Continue for no reason. Before finishing a tutorial, scan every `### Exercise N` header and confirm a `question_text()` chunk appears before the next `###`; if one is missing, either write a real question or remove the heading and fold the content into the next exercise's preamble (see below).
 
 The pattern, when an author-shown chunk needs a pause:
 


### PR DESCRIPTION
## Summary
`guide/authoring.md` §6.5 already forbids a fake placeholder `question_text()` ("no command to run, just Continue"). But 08-seguro-popular's Courage Exercise 10 shipped a different variant of the same mistake: an `### Exercise N` heading followed only by prose and a formula, with **no** `question_text()` chunk . Nothing in the guide explicitly named that as the same violation, so it read as compliant on a literal pass even though it broke the rule's spirit. 

 - `### Exercise N` heading must be followed by an actual `question_text()` chunk before the next `###`/`##` heading
- Also adds an explicit pre-submission self-check instruction (scan every Exercise header, confirm a question_text() chunk follows it).

- the fake exercise heading was removed, its formula content folded into the following exercise's preamble, and the rest of the Courage section renumbered (Exercise 10 -> 13, chunk labels `courage-10` through `courage-13`).
